### PR TITLE
Added sketch analytical tracking to calling url

### DIFF
--- a/Random User/randomUserCommon.js
+++ b/Random User/randomUserCommon.js
@@ -1,6 +1,6 @@
 function getRandomUser()
 {
-  var theUrl = [NSURL URLWithString:"http://api.randomuser.me/"];
+  var theUrl = [NSURL URLWithString:"http://api.randomuser.me/?sketch=true"];
 
   // define the request
   var theRequest = NSMutableURLRequest.requestWithURL_cachePolicy_timeoutInterval(theUrl, NSURLRequestReloadIgnoringLocalCacheData, 60);


### PR DESCRIPTION
The sketch flag is purely for analytical purposes and it helps us see where our API requests are coming from.
No personal info will be stored.
